### PR TITLE
chore(cicd): Fix release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
     contents: write
     issues: write
     deployments: write
+    id-token: write # to enable use of OIDC for npm provenance
 
 jobs:
   setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - development
       - next
-      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Update release GitHub action in the following ways:

- Adding missing `id-token` permission (might actually not be needed since `provenance` is not set to true, but in case it is in the future, it will work).
- Not run automatically on push to main. The reason I changed this is because this way we can choose when to release a stable, in case we want to bundle multiple features / fixes. Releases are still running automatically for non-stable branches.