### PR TITLE
chore(android): use 'propName = value' assignment syntax in build.gradle files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
-    namespace "com.capacitorjs.plugins.privacyscreen"
-    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 36
+    namespace = "com.capacitorjs.plugins.privacyscreen"
+    compileSdk = project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 36
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 24
         targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 36
@@ -38,7 +38,7 @@ android {
         }
     }
     lintOptions {
-        abortOnError false
+        abortOnError = false
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_21


### PR DESCRIPTION
This PR updates all Android build.gradle files in the plugins to use the recommended property assignment syntax: propName = value.